### PR TITLE
Fix get-documents to return JSON instead of Python objects

### DIFF
--- a/src/meilisearch_mcp/documents.py
+++ b/src/meilisearch_mcp/documents.py
@@ -18,9 +18,43 @@ class DocumentManager:
         """Get documents from an index"""
         try:
             index = self.client.index(index_uid)
-            return index.get_documents(
-                {"offset": offset, "limit": limit, "fields": fields}
-            )
+            # Build parameters dict, excluding None values to avoid API errors
+            params = {}
+            if offset is not None:
+                params["offset"] = offset
+            if limit is not None:
+                params["limit"] = limit
+            if fields is not None:
+                params["fields"] = fields
+            
+            result = index.get_documents(params if params else {})
+            
+            # Convert meilisearch model objects to JSON-serializable format
+            if hasattr(result, '__dict__'):
+                result_dict = result.__dict__.copy()
+                # Convert individual document objects in results if they exist
+                if 'results' in result_dict and isinstance(result_dict['results'], list):
+                    serialized_results = []
+                    for doc in result_dict['results']:
+                        if hasattr(doc, '__dict__'):
+                            # Extract the actual document data
+                            doc_dict = doc.__dict__.copy()
+                            # Look for private attributes that might contain the actual data
+                            for key, value in doc_dict.items():
+                                if key.startswith('_') and isinstance(value, dict):
+                                    # Use the dict content instead of the wrapper
+                                    serialized_results.append(value)
+                                    break
+                            else:
+                                # If no private dict found, use the object dict directly
+                                serialized_results.append(doc_dict)
+                        else:
+                            serialized_results.append(doc)
+                    result_dict['results'] = serialized_results
+                return result_dict
+            else:
+                return result
+                
         except Exception as e:
             raise Exception(f"Failed to get documents: {str(e)}")
 


### PR DESCRIPTION
## Summary

Fixes #16: The `get-documents` tool was returning Python object string representations instead of proper JSON-formatted data.

## Problem

The issue reported that `get-documents` was returning:
```
Documents: <meilisearch.models.document.DocumentsResults object at 0x...>
```

Instead of actual JSON with accessible document fields.

## Solution

### Core Changes
- **documents.py**: Enhanced `get_documents()` to properly serialize `DocumentsResults` and `Document` objects to JSON-compatible dictionaries
- **server.py**: Improved `json_serializer()` to handle Meilisearch model objects using `__dict__` attributes
- Added proper JSON formatting with `json.dumps()` for the get-documents tool response
- Added default values for `offset` (0) and `limit` (20) to prevent None parameter API errors

### Test Coverage
- Added `TestIssue16GetDocumentsJsonSerialization` with focused test for this specific issue
- Verifies no Python object representations in response
- Confirms actual document data is accessible in JSON format
- Validates proper JSON structure

## Before vs After

**Before:**
```
Documents: <meilisearch.models.document.DocumentsResults object at 0x...>
```

**After:**
```json
Documents:
{
  "results": [
    {
      "id": 1,
      "title": "Test Document",
      "content": "Test content"
    }
  ],
  "offset": 0,
  "limit": 20,
  "total": 1
}
```

## Testing

```bash
python -m pytest tests/test_mcp_client.py::TestIssue16GetDocumentsJsonSerialization -v
```

Test confirms:
- ✅ No Python object string representations
- ✅ Valid JSON structure
- ✅ Document fields are accessible

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved JSON serialization for document retrieval, ensuring responses are properly formatted as JSON rather than Python object strings.
	- Default values for pagination parameters are now applied to prevent issues when values are not provided.
- **Tests**
	- Added new tests to verify that document retrieval returns correctly formatted JSON responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->