### PR TITLE
Update Docker Hub organization to getmeili

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: meilisearch/meilisearch-mcp
+          images: getmeili/meilisearch-mcp
           tags: |
             type=raw,value=${{ needs.check-version.outputs.new_version }}
             type=raw,value=latest

--- a/README.md
+++ b/README.md
@@ -145,16 +145,16 @@ Perfect for containerized environments like n8n workflows!
 
 ```bash
 # Pull the latest image
-docker pull meilisearch/meilisearch-mcp:latest
+docker pull getmeili/meilisearch-mcp:latest
 
 # Or a specific version
-docker pull meilisearch/meilisearch-mcp:0.5.0
+docker pull getmeili/meilisearch-mcp:0.5.0
 
 # Run the container
 docker run -it \
   -e MEILI_HTTP_ADDR=http://your-meilisearch:7700 \
   -e MEILI_MASTER_KEY=your-master-key \
-  meilisearch/meilisearch-mcp:latest
+  getmeili/meilisearch-mcp:latest
 ```
 
 #### Build from Source
@@ -173,7 +173,7 @@ docker run -it \
 For n8n workflows, you can use the Docker image directly in your setup:
 ```yaml
 meilisearch-mcp:
-  image: meilisearch/meilisearch-mcp:latest
+  image: getmeili/meilisearch-mcp:latest
   environment:
     - MEILI_HTTP_ADDR=http://meilisearch:7700
     - MEILI_MASTER_KEY=masterKey


### PR DESCRIPTION
## Summary
This PR updates the Docker Hub image name from `meilisearch/meilisearch-mcp` to `getmeili/meilisearch-mcp` to align with the official Meilisearch Docker Hub organization.

## Changes Made

### 🐳 Docker Hub Organization Update
- Updated `publish.yml` workflow to push images to `getmeili/meilisearch-mcp`
- Updated all Docker image references in README to use `getmeili/meilisearch-mcp`

### 🧹 Docker Compose Removal
As discussed, also removed docker-compose entirely from the repository:
- Removed `docker-compose.yml` and `docker-compose.prod.yml` files
- Simplified Docker tests to only test image build and basic run
- Updated README to remove all docker-compose references
- Removed separate docker-test job from CI workflow

## Why These Changes?

1. **Correct Organization**: The Docker images should be published under the official `getmeili` organization, not personal workspaces
2. **Simplified Repository**: Removing docker-compose keeps the repository focused on providing just the Docker image
3. **Cleaner Testing**: Docker tests now only verify that the image builds and runs correctly

## Docker Usage

Users can now pull and run the image directly:
```bash
docker pull getmeili/meilisearch-mcp:latest
docker run -it \
  -e MEILI_HTTP_ADDR=http://your-meilisearch:7700 \
  -e MEILI_MASTER_KEY=your-master-key \
  getmeili/meilisearch-mcp:latest
```

## Note
The Docker Hub secrets (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) should be configured to use the `getmeili` organization credentials.