### PR TITLE
Publish Docker images on every main commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,19 +10,26 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version_changed: ${{ steps.check_version.outputs.version_changed }}
-      new_version: ${{ steps.check_version.outputs.new_version }}
+      current_version: ${{ steps.get_version.outputs.current_version }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       
+      - name: Get current version
+        id: get_version
+        run: |
+          CURRENT_VERSION=$(grep "version = " pyproject.toml | cut -d'"' -f2)
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+      
       - name: Check if version changed
         id: check_version
         run: |
-          git diff HEAD^ HEAD -- pyproject.toml | grep -q "version = " || exit 0
-          NEW_VERSION=$(grep "version = " pyproject.toml | cut -d'"' -f2)
-          echo "version_changed=true" >> $GITHUB_OUTPUT
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          if git diff HEAD^ HEAD -- pyproject.toml | grep -q "version = "; then
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          fi
 
   build-and-publish-pypi:
     needs: check-version
@@ -56,7 +63,35 @@ jobs:
           verbose: true
           print-hash: true
 
-  build-and-publish-docker:
+  build-and-publish-docker-latest:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Build and push latest Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: getmeili/meilisearch-mcp:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-publish-docker-versioned:
     needs: check-version
     if: needs.check-version.outputs.version_changed == 'true'
     runs-on: ubuntu-latest
@@ -76,22 +111,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: getmeili/meilisearch-mcp
-          tags: |
-            type=raw,value=${{ needs.check-version.outputs.new_version }}
-            type=raw,value=latest
-      
-      - name: Build and push Docker image
+      - name: Build and push versioned Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: getmeili/meilisearch-mcp:${{ needs.check-version.outputs.current_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ uv pip install -e .
 
 Perfect for containerized environments like n8n workflows!
 
-#### From Docker Hub (Recommended)
+#### From Docker Hub
 
 ```bash
 # Pull the latest image


### PR DESCRIPTION
## Summary
This PR updates the Docker publishing workflow to ensure Docker images are always available on Docker Hub by:
- Publishing a `latest` tag on every commit to main
- Publishing versioned tags (e.g., `0.5.0`) only when the version changes

## Problem
Currently, no Docker images exist on Docker Hub because the workflow only runs when the version changes. This means users can't use the Docker image until a new release is made.

## Solution
Split the Docker publishing into two separate jobs:
1. **`build-and-publish-docker-latest`** - Runs on EVERY main commit, always updates the `latest` tag
2. **`build-and-publish-docker-versioned`** - Runs ONLY when version changes, creates version-specific tags

## Changes Made
- Updated `.github/workflows/publish.yml` to have separate Docker build jobs
- Always publish `getmeili/meilisearch-mcp:latest` on main commits
- Publish `getmeili/meilisearch-mcp:X.Y.Z` only on version changes
- Minor README update to remove "(Recommended)" text

## Result
After this PR is merged:
- Every commit to main will update the `latest` Docker image
- Users can immediately start using `docker pull getmeili/meilisearch-mcp:latest`
- Version releases will create additional tagged images for stability

## Note
The Docker Hub credentials (`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`) need to be configured in the repository secrets for the `getmeili` organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved workflow for Docker image publishing by separating jobs for latest and versioned tags, and simplifying version detection logic.
- **Documentation**
  - Updated installation instructions in the README by removing the "(Recommended)" label from the "From Docker Hub" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->