### PR TITLE
feat: allow sematic search in mcp tool

### DIFF
--- a/src/meilisearch_mcp/server.py
+++ b/src/meilisearch_mcp/server.py
@@ -227,6 +227,13 @@ class MeilisearchMCPServer:
                                 "type": "array",
                                 "items": {"type": "string"},
                             },
+                            "hybrid": {
+                                "type": "object",
+                                "properties": {
+                                    "embedder": {"type": "string", "default": "default"},
+                                    "semanticRatio": {"type": "number"},
+                                },
+                            },
                         },
                         "required": ["query"],
                         "additionalProperties": False,
@@ -592,6 +599,7 @@ class MeilisearchMCPServer:
                         offset=arguments.get("offset"),
                         filter=arguments.get("filter"),
                         sort=arguments.get("sort"),
+                        hybrid=arguments.get("hybrid"),
                     )
 
                     # Format the results for better readability


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
Currently the list of args for the search tool does not accept [`hybrid` params](https://www.meilisearch.com/docs/reference/api/search/search-with-post#body-hybrid-one-of-1). This restricts search to use only full-text.

No ai was used, this was like 5 lines of code. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
